### PR TITLE
Addition of account names and twitter handles to the image alt attributes

### DIFF
--- a/app/Services/Twitter.php
+++ b/app/Services/Twitter.php
@@ -88,6 +88,8 @@ class Twitter
     {
         $this->users[$user['id_str']] = [
             'id' => $user['id_str'],
+            'name' => $user['name'],
+            'screen_name' => $user['screen_name'],
             'avatar' => str_replace('normal', '400x400', $user['profile_image_url_https']),
             'fav' => $fav,
             'reply' => $reply,

--- a/resources/views/result.blade.php
+++ b/resources/views/result.blade.php
@@ -10,9 +10,9 @@
 <body>
     <div class="wrapper">
         <div class="image-container">
-            <img src="{{ str_replace('normal', '400x400', $currentUser['profile_image_url_https']) }}" class="img" alt="" style="border-radius: 100%;">
+            <img src="{{ str_replace('normal', '400x400', $currentUser['profile_image_url_https']) }}" class="img" alt="{{ $currentUser['name'] }} ({{ $currentUser['screen_name'] }})" style="border-radius: 100%;">
             @foreach($users as $key => $user)
-                <img src="{{ $user['avatar'] }}" style="border-radius: 100%;" alt="" class="img @if($key >= 0 && $key <= 7) img-1 @elseif($key >= 8 && $key <= 23) img-2 @elseif($key >= 24 && $key <= 51) img-3 @endif">
+                <img src="{{ $user['avatar'] }}" style="border-radius: 100%;" alt="{{ $user['name'] }} ({{ $user['screen_name'] }})" class="img @if($key >= 0 && $key <= 7) img-1 @elseif($key >= 8 && $key <= 23) img-2 @elseif($key >= 24 && $key <= 51) img-3 @endif">
             @endforeach
             <a class="brand" href="{{ url('/') }}">circle.ibio.link</a>
         </div>


### PR DESCRIPTION
This change adds the ability for non-sighted users to hear a list of names and usernames that are available to sighted users.

![alt-text](https://user-images.githubusercontent.com/37359/104243300-5e2a6e80-542e-11eb-98ec-a2d89084ad24.jpg)
